### PR TITLE
Fix double slash in API path for networking

### DIFF
--- a/modules/client/src/main/scala/apis/NetworkingV1.scala
+++ b/modules/client/src/main/scala/apis/NetworkingV1.scala
@@ -24,5 +24,5 @@ trait NetworkingV1 {
 }
 
 object NetworkingV1
-    extends APIGroupAPI("/apis/networking.k8s.io/v1/")
+    extends APIGroupAPI("/apis/networking.k8s.io/v1")
     with NetworkingV1


### PR DESCRIPTION
Currently with `object NetworkingV1 extends APIGroupAPI("/apis/networking.k8s.io/v1/")` we are getting API path with double slashes - "/apis/networking.k8s.io/v1//namespaces/default/ingresses".

Since others APIGroupAPI don't have ending slash, looks like it's not intended to have ending slash here.