### PR TITLE
Add RBAC, Policy, Autoscaling, Storage API groups

### DIFF
--- a/modules/client/src/main/scala/apis/AutoscalingV1.scala
+++ b/modules/client/src/main/scala/apis/AutoscalingV1.scala
@@ -16,19 +16,12 @@
 
 package dev.hnaderi.k8s.client
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
+import apis.autoscalingv1._
+
+trait AutoscalingV1 {
+  final val horizontalPodAutoscalersV1 = ClusterHorizontalPodAutoscalerV1API
 }
 
-object APIs extends APIs
+object AutoscalingV1
+    extends APIGroupAPI("/apis/autoscaling/v1")
+    with AutoscalingV1

--- a/modules/client/src/main/scala/apis/AutoscalingV1Namespaced.scala
+++ b/modules/client/src/main/scala/apis/AutoscalingV1Namespaced.scala
@@ -16,19 +16,9 @@
 
 package dev.hnaderi.k8s.client
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
-}
+import apis.autoscalingv1._
 
-object APIs extends APIs
+trait AutoscalingV1Namespaced { self: NamespacedAPI =>
+  final val horizontalPodAutoscalersV1: HorizontalPodAutoscalerV1API =
+    HorizontalPodAutoscalerV1API(namespace)
+}

--- a/modules/client/src/main/scala/apis/AutoscalingV2.scala
+++ b/modules/client/src/main/scala/apis/AutoscalingV2.scala
@@ -16,19 +16,12 @@
 
 package dev.hnaderi.k8s.client
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
+import apis.autoscalingv2._
+
+trait AutoscalingV2 {
+  final val horizontalPodAutoscalersV2 = ClusterHorizontalPodAutoscalerV2API
 }
 
-object APIs extends APIs
+object AutoscalingV2
+    extends APIGroupAPI("/apis/autoscaling/v2")
+    with AutoscalingV2

--- a/modules/client/src/main/scala/apis/AutoscalingV2Namespaced.scala
+++ b/modules/client/src/main/scala/apis/AutoscalingV2Namespaced.scala
@@ -16,19 +16,9 @@
 
 package dev.hnaderi.k8s.client
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
-}
+import apis.autoscalingv2._
 
-object APIs extends APIs
+trait AutoscalingV2Namespaced { self: NamespacedAPI =>
+  final val horizontalPodAutoscalersV2: HorizontalPodAutoscalerV2API =
+    HorizontalPodAutoscalerV2API(namespace)
+}

--- a/modules/client/src/main/scala/apis/CoreV1.scala
+++ b/modules/client/src/main/scala/apis/CoreV1.scala
@@ -28,6 +28,8 @@ trait CoreV1 {
   final val events = ClusterEventAPI
   final val serviceAccounts = ClusterServiceAccountAPI
   final val resourceQuotas = ClusterResourceQuotaAPI
+  final val persistentVolumes = PersistentVolumeAPI
+  final val persistentVolumeClaims = ClusterPersistentVolumeClaimAPI
 }
 
 object CoreV1 extends APIGroupAPI("/api/v1") with CoreV1

--- a/modules/client/src/main/scala/apis/CoreV1Namespaced.scala
+++ b/modules/client/src/main/scala/apis/CoreV1Namespaced.scala
@@ -28,5 +28,7 @@ trait CoreV1Namespaced { self: NamespacedAPI =>
   final val events: EventAPI = EventAPI(namespace)
   final val serviceAccounts: ServiceAccountAPI = ServiceAccountAPI(namespace)
   final val resourceQuotas: ResourceQuotaAPI = ResourceQuotaAPI(namespace)
+  final val persistentVolumeClaims: PersistentVolumeClaimAPI =
+    PersistentVolumeClaimAPI(namespace)
 
 }

--- a/modules/client/src/main/scala/apis/NamespaceAPI.scala
+++ b/modules/client/src/main/scala/apis/NamespaceAPI.scala
@@ -24,6 +24,10 @@ final case class NamespaceAPI(namespace: String)
     with AppsV1Namespaced
     with BatchV1Namespaced
     with NetworkingV1Namespaced
+    with RbacV1Namespaced
+    with PolicyV1Namespaced
+    with AutoscalingV1Namespaced
+    with AutoscalingV2Namespaced
     with NamespacedAPI
 
 object NamespaceAPI {

--- a/modules/client/src/main/scala/apis/NamespacedAPI.scala
+++ b/modules/client/src/main/scala/apis/NamespacedAPI.scala
@@ -217,6 +217,23 @@ abstract class APIGroupAPI(base: String) {
           force = force
         )
 
+    case class GetStatus(namespace: String, name: String)
+        extends GetRequest[RES](urlFor(namespace, name) + "/status")
+    case class ReplaceStatus(
+        namespace: String,
+        name: String,
+        body: RES,
+        dryRun: Option[String] = None,
+        fieldManager: Option[String] = None,
+        fieldValidation: Option[String] = None
+    ) extends ReplaceRequest[RES](
+          urlFor(namespace, name) + "/status",
+          body,
+          dryRun = dryRun,
+          fieldManager = fieldManager,
+          fieldValidation = fieldValidation
+        )
+
     trait NamespacedAPIBuilders extends NamespacedAPI {
       def get(name: String): Get = Get(namespace, name)
       def list(
@@ -396,6 +413,21 @@ abstract class APIGroupAPI(base: String) {
         dryRun = dryRun,
         force = force
       )
+      def getStatus(name: String): GetStatus = GetStatus(namespace, name)
+      def replaceStatus(
+          name: String,
+          body: RES,
+          dryRun: Option[String] = None,
+          fieldManager: Option[String] = None,
+          fieldValidation: Option[String] = None
+      ): ReplaceStatus = ReplaceStatus(
+        namespace,
+        name,
+        body,
+        dryRun = dryRun,
+        fieldManager = fieldManager,
+        fieldValidation = fieldValidation
+      )
     }
   }
 
@@ -505,6 +537,22 @@ abstract class APIGroupAPI(base: String) {
           fieldValidation = fieldValidation,
           fieldManager = fieldManager,
           force = force
+        )
+
+    case class GetStatus(name: String)
+        extends GetRequest[RES](urlFor(name) + "/status")
+    case class ReplaceStatus(
+        name: String,
+        body: RES,
+        dryRun: Option[String] = None,
+        fieldManager: Option[String] = None,
+        fieldValidation: Option[String] = None
+    ) extends ReplaceRequest[RES](
+          urlFor(name) + "/status",
+          body,
+          dryRun = dryRun,
+          fieldManager = fieldManager,
+          fieldValidation = fieldValidation
         )
 
     def get(name: String): Get = Get(name)
@@ -674,6 +722,20 @@ abstract class APIGroupAPI(base: String) {
       fieldValidation = fieldValidation,
       dryRun = dryRun,
       force = force
+    )
+    def getStatus(name: String): GetStatus = GetStatus(name)
+    def replaceStatus(
+        name: String,
+        body: RES,
+        dryRun: Option[String] = None,
+        fieldManager: Option[String] = None,
+        fieldValidation: Option[String] = None
+    ): ReplaceStatus = ReplaceStatus(
+      name,
+      body,
+      dryRun = dryRun,
+      fieldManager = fieldManager,
+      fieldValidation = fieldValidation
     )
 
   }

--- a/modules/client/src/main/scala/apis/PolicyV1.scala
+++ b/modules/client/src/main/scala/apis/PolicyV1.scala
@@ -16,19 +16,10 @@
 
 package dev.hnaderi.k8s.client
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
+import apis.policyv1._
+
+trait PolicyV1 {
+  final val podDisruptionBudgets = ClusterPodDisruptionBudgetAPI
 }
 
-object APIs extends APIs
+object PolicyV1 extends APIGroupAPI("/apis/policy/v1") with PolicyV1

--- a/modules/client/src/main/scala/apis/PolicyV1Namespaced.scala
+++ b/modules/client/src/main/scala/apis/PolicyV1Namespaced.scala
@@ -16,19 +16,9 @@
 
 package dev.hnaderi.k8s.client
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
-}
+import apis.policyv1._
 
-object APIs extends APIs
+trait PolicyV1Namespaced { self: NamespacedAPI =>
+  final val podDisruptionBudgets: PodDisruptionBudgetAPI =
+    PodDisruptionBudgetAPI(namespace)
+}

--- a/modules/client/src/main/scala/apis/RbacV1.scala
+++ b/modules/client/src/main/scala/apis/RbacV1.scala
@@ -16,19 +16,15 @@
 
 package dev.hnaderi.k8s.client
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
+import apis.rbacv1._
+
+trait RbacV1 {
+  final val roles = ClusterRoleListAPI
+  final val roleBindings = ClusterRoleBindingListAPI
+  final val clusterRoles = ClusterRoleAPI
+  final val clusterRoleBindings = ClusterRoleBindingAPI
 }
 
-object APIs extends APIs
+object RbacV1
+    extends APIGroupAPI("/apis/rbac.authorization.k8s.io/v1")
+    with RbacV1

--- a/modules/client/src/main/scala/apis/RbacV1Namespaced.scala
+++ b/modules/client/src/main/scala/apis/RbacV1Namespaced.scala
@@ -16,19 +16,9 @@
 
 package dev.hnaderi.k8s.client
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
-}
+import apis.rbacv1._
 
-object APIs extends APIs
+trait RbacV1Namespaced { self: NamespacedAPI =>
+  final val roles: RoleAPI = RoleAPI(namespace)
+  final val roleBindings: RoleBindingAPI = RoleBindingAPI(namespace)
+}

--- a/modules/client/src/main/scala/apis/StorageV1.scala
+++ b/modules/client/src/main/scala/apis/StorageV1.scala
@@ -16,19 +16,10 @@
 
 package dev.hnaderi.k8s.client
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
+import apis.storagev1._
+
+trait StorageV1 {
+  final val storageClasses = StorageClassAPI
 }
 
-object APIs extends APIs
+object StorageV1 extends APIGroupAPI("/apis/storage.k8s.io/v1") with StorageV1

--- a/modules/client/src/main/scala/apis/autoscaling/HorizontalPodAutoscalerV1API.scala
+++ b/modules/client/src/main/scala/apis/autoscaling/HorizontalPodAutoscalerV1API.scala
@@ -15,20 +15,19 @@
  */
 
 package dev.hnaderi.k8s.client
+package apis.autoscalingv1
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
-}
+import io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler
+import io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList
 
-object APIs extends APIs
+object HorizontalPodAutoscalerV1API
+    extends AutoscalingV1.NamespacedResourceAPI[
+      HorizontalPodAutoscaler,
+      HorizontalPodAutoscalerList
+    ]("horizontalpodautoscalers")
+
+final case class HorizontalPodAutoscalerV1API(namespace: String)
+    extends HorizontalPodAutoscalerV1API.NamespacedAPIBuilders
+
+object ClusterHorizontalPodAutoscalerV1API
+    extends HorizontalPodAutoscalerV1API.ClusterwideAPIBuilders

--- a/modules/client/src/main/scala/apis/autoscaling/HorizontalPodAutoscalerV2API.scala
+++ b/modules/client/src/main/scala/apis/autoscaling/HorizontalPodAutoscalerV2API.scala
@@ -15,20 +15,19 @@
  */
 
 package dev.hnaderi.k8s.client
+package apis.autoscalingv2
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
-}
+import io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler
+import io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList
 
-object APIs extends APIs
+object HorizontalPodAutoscalerV2API
+    extends AutoscalingV2.NamespacedResourceAPI[
+      HorizontalPodAutoscaler,
+      HorizontalPodAutoscalerList
+    ]("horizontalpodautoscalers")
+
+final case class HorizontalPodAutoscalerV2API(namespace: String)
+    extends HorizontalPodAutoscalerV2API.NamespacedAPIBuilders
+
+object ClusterHorizontalPodAutoscalerV2API
+    extends HorizontalPodAutoscalerV2API.ClusterwideAPIBuilders

--- a/modules/client/src/main/scala/apis/certificates/CertificateSigningRequestAPI.scala
+++ b/modules/client/src/main/scala/apis/certificates/CertificateSigningRequestAPI.scala
@@ -54,31 +54,4 @@ object CertificateSigningRequestAPI
     fieldValidation = fieldValidation
   )
 
-  case class StatusRequest(
-      name: String,
-      body: CertificateSigningRequest,
-      dryRun: Option[String] = None,
-      fieldManager: Option[String] = None,
-      fieldValidation: Option[String] = None
-  ) extends ReplaceRequest(
-        s"${urlFor(name)}/status",
-        body,
-        dryRun = dryRun,
-        fieldManager = fieldManager,
-        fieldValidation = fieldValidation
-      )
-
-  def replaceStatus(
-      name: String,
-      csr: CertificateSigningRequest,
-      dryRun: Option[String] = None,
-      fieldManager: Option[String] = None,
-      fieldValidation: Option[String] = None
-  ): StatusRequest = StatusRequest(
-    name,
-    csr,
-    dryRun = dryRun,
-    fieldManager = fieldManager,
-    fieldValidation = fieldValidation
-  )
 }

--- a/modules/client/src/main/scala/apis/core/PersistentVolumeAPI.scala
+++ b/modules/client/src/main/scala/apis/core/PersistentVolumeAPI.scala
@@ -15,20 +15,12 @@
  */
 
 package dev.hnaderi.k8s.client
+package apis.corev1
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
-}
+import io.k8s.api.core.v1.PersistentVolume
+import io.k8s.api.core.v1.PersistentVolumeList
 
-object APIs extends APIs
+object PersistentVolumeAPI
+    extends CoreV1.ClusterResourceAPI[PersistentVolume, PersistentVolumeList](
+      "persistentvolumes"
+    )

--- a/modules/client/src/main/scala/apis/core/PersistentVolumeClaimAPI.scala
+++ b/modules/client/src/main/scala/apis/core/PersistentVolumeClaimAPI.scala
@@ -15,20 +15,21 @@
  */
 
 package dev.hnaderi.k8s.client
+package apis.corev1
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
-}
+import io.k8s.api.core.v1.PersistentVolumeClaim
+import io.k8s.api.core.v1.PersistentVolumeClaimList
 
-object APIs extends APIs
+object PersistentVolumeClaimAPI
+    extends CoreV1.NamespacedResourceAPI[
+      PersistentVolumeClaim,
+      PersistentVolumeClaimList
+    ](
+      "persistentvolumeclaims"
+    )
+
+final case class PersistentVolumeClaimAPI(namespace: String)
+    extends PersistentVolumeClaimAPI.NamespacedAPIBuilders
+
+object ClusterPersistentVolumeClaimAPI
+    extends PersistentVolumeClaimAPI.ClusterwideAPIBuilders

--- a/modules/client/src/main/scala/apis/core/PodAPI.scala
+++ b/modules/client/src/main/scala/apis/core/PodAPI.scala
@@ -118,22 +118,6 @@ object PodAPI
         limitBytes = limitBytes
       )
 
-  case class GetStatus(namespace: String, name: String)
-      extends GetRequest[Pod](PodAPI.urlFor(namespace, name) + "/status")
-  case class ReplaceStatus(
-      namespace: String,
-      name: String,
-      body: Pod,
-      dryRun: Option[String] = None,
-      fieldManager: Option[String] = None,
-      fieldValidation: Option[String] = None
-  ) extends ReplaceRequest[Pod](
-        PodAPI.urlFor(namespace, name) + "/status",
-        body,
-        dryRun = dryRun,
-        fieldManager = fieldManager,
-        fieldValidation = fieldValidation
-      )
   case class Evict(
       namespace: String,
       name: String,
@@ -211,23 +195,6 @@ final case class PodAPI(namespace: String)
     limitBytes = limitBytes
   )
 
-  def getStatus(name: String): PodAPI.GetStatus =
-    PodAPI.GetStatus(namespace, name)
-  def replaceStatus(
-      name: String,
-      body: Pod,
-      dryRun: Option[String] = None,
-      fieldManager: Option[String] = None,
-      fieldValidation: Option[String] = None
-  ): PodAPI.ReplaceStatus =
-    PodAPI.ReplaceStatus(
-      namespace,
-      name,
-      body,
-      dryRun = dryRun,
-      fieldManager = fieldManager,
-      fieldValidation = fieldValidation
-    )
   def evict(
       name: String,
       eviction: Eviction = Eviction(),

--- a/modules/client/src/main/scala/apis/policy/PodDisruptionBudgetAPI.scala
+++ b/modules/client/src/main/scala/apis/policy/PodDisruptionBudgetAPI.scala
@@ -15,20 +15,21 @@
  */
 
 package dev.hnaderi.k8s.client
+package apis.policyv1
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
-}
+import io.k8s.api.policy.v1.PodDisruptionBudget
+import io.k8s.api.policy.v1.PodDisruptionBudgetList
 
-object APIs extends APIs
+object PodDisruptionBudgetAPI
+    extends PolicyV1.NamespacedResourceAPI[
+      PodDisruptionBudget,
+      PodDisruptionBudgetList
+    ](
+      "poddisruptionbudgets"
+    )
+
+final case class PodDisruptionBudgetAPI(namespace: String)
+    extends PodDisruptionBudgetAPI.NamespacedAPIBuilders
+
+object ClusterPodDisruptionBudgetAPI
+    extends PodDisruptionBudgetAPI.ClusterwideAPIBuilders

--- a/modules/client/src/main/scala/apis/rbac/ClusterRoleAPI.scala
+++ b/modules/client/src/main/scala/apis/rbac/ClusterRoleAPI.scala
@@ -15,20 +15,12 @@
  */
 
 package dev.hnaderi.k8s.client
+package apis.rbacv1
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
-}
+import io.k8s.api.rbac.v1.ClusterRole
+import io.k8s.api.rbac.v1.ClusterRoleList
 
-object APIs extends APIs
+object ClusterRoleAPI
+    extends RbacV1.ClusterResourceAPI[ClusterRole, ClusterRoleList](
+      "clusterroles"
+    )

--- a/modules/client/src/main/scala/apis/rbac/ClusterRoleBindingAPI.scala
+++ b/modules/client/src/main/scala/apis/rbac/ClusterRoleBindingAPI.scala
@@ -15,20 +15,15 @@
  */
 
 package dev.hnaderi.k8s.client
+package apis.rbacv1
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
-}
+import io.k8s.api.rbac.v1.ClusterRoleBinding
+import io.k8s.api.rbac.v1.ClusterRoleBindingList
 
-object APIs extends APIs
+object ClusterRoleBindingAPI
+    extends RbacV1.ClusterResourceAPI[
+      ClusterRoleBinding,
+      ClusterRoleBindingList
+    ](
+      "clusterrolebindings"
+    )

--- a/modules/client/src/main/scala/apis/rbac/RoleAPI.scala
+++ b/modules/client/src/main/scala/apis/rbac/RoleAPI.scala
@@ -15,20 +15,14 @@
  */
 
 package dev.hnaderi.k8s.client
+package apis.rbacv1
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
-}
+import io.k8s.api.rbac.v1.Role
+import io.k8s.api.rbac.v1.RoleList
 
-object APIs extends APIs
+object RoleAPI extends RbacV1.NamespacedResourceAPI[Role, RoleList]("roles")
+
+final case class RoleAPI(namespace: String)
+    extends RoleAPI.NamespacedAPIBuilders
+
+object ClusterRoleListAPI extends RoleAPI.ClusterwideAPIBuilders

--- a/modules/client/src/main/scala/apis/rbac/RoleBindingAPI.scala
+++ b/modules/client/src/main/scala/apis/rbac/RoleBindingAPI.scala
@@ -15,20 +15,17 @@
  */
 
 package dev.hnaderi.k8s.client
+package apis.rbacv1
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
-}
+import io.k8s.api.rbac.v1.RoleBinding
+import io.k8s.api.rbac.v1.RoleBindingList
 
-object APIs extends APIs
+object RoleBindingAPI
+    extends RbacV1.NamespacedResourceAPI[RoleBinding, RoleBindingList](
+      "rolebindings"
+    )
+
+final case class RoleBindingAPI(namespace: String)
+    extends RoleBindingAPI.NamespacedAPIBuilders
+
+object ClusterRoleBindingListAPI extends RoleBindingAPI.ClusterwideAPIBuilders

--- a/modules/client/src/main/scala/apis/storage/StorageClassAPI.scala
+++ b/modules/client/src/main/scala/apis/storage/StorageClassAPI.scala
@@ -15,20 +15,12 @@
  */
 
 package dev.hnaderi.k8s.client
+package apis.storagev1
 
-trait APIs
-    extends CoreV1
-    with AppsV1
-    with BatchV1
-    with NetworkingV1
-    with APIExtensionsV1
-    with RbacV1
-    with PolicyV1
-    with AutoscalingV1
-    with AutoscalingV2
-    with StorageV1 {
-  val namespaces = NamespaceAPI
-  def namespace(name: String) = NamespaceAPI(name)
-}
+import io.k8s.api.storage.v1.StorageClass
+import io.k8s.api.storage.v1.StorageClassList
 
-object APIs extends APIs
+object StorageClassAPI
+    extends StorageV1.ClusterResourceAPI[StorageClass, StorageClassList](
+      "storageclasses"
+    )


### PR DESCRIPTION
Add RBAC, Policy, Autoscaling, Storage API groups and promote status to base class
  - Add getStatus/replaceStatus to NamespacedResourceAPI and ClusterResourceAPI
    so every resource gets the /status sub-resource automatically; remove the
    now-redundant copies from PodAPI and CertificateSigningRequestAPI
  - Add PersistentVolume (cluster) and PersistentVolumeClaim (namespaced) to CoreV1
  - Add rbac.authorization.k8s.io/v1: Role, RoleBinding, ClusterRole, ClusterRoleBinding
  - Add policy/v1: PodDisruptionBudget
  - Add autoscaling/v1 and autoscaling/v2: HorizontalPodAutoscaler (both versions
    exposed as horizontalPodAutoscalersV1 / horizontalPodAutoscalersV2 to avoid conflict)
  - Add storage.k8s.io/v1: StorageClass
  - Wire all new namespaced resources into NamespaceAPI and APIs
